### PR TITLE
fixed SvgAttrribute reflection for .net core. (i guess Equals() funct…

### DIFF
--- a/Source/SvgAttributeAttribute.cs
+++ b/Source/SvgAttributeAttribute.cs
@@ -30,6 +30,11 @@ namespace Svg
         private string _name;
         private string _namespace;
 
+        public override bool Equals(object obj)
+        {
+            return Match(obj);
+        }
+
         /// <summary>
         /// When overridden in a derived class, returns a value that indicates whether this instance equals a specified object.
         /// </summary>


### PR DESCRIPTION
…ion is called instead of Match() on this platform?)